### PR TITLE
fix: md5 require removal on service worker

### DIFF
--- a/dist/md5_worker.js
+++ b/dist/md5_worker.js
@@ -397,8 +397,7 @@ var Md5 = /** @class */ (function () {
 if (Md5.hashStr('hello') !== '5d41402abc4b2a76b9719d911017c592') {
     console.error('Md5 self test failed.');
 }
-//# sourceMappingURL=md5.js.map"use strict";
-var md5_1 = require("./md5");
+
 // Hashes any blob
 var Md5FileHasher = /** @class */ (function () {
     function Md5FileHasher(_callback, // Callback to return the result
@@ -416,7 +415,7 @@ var Md5FileHasher = /** @class */ (function () {
         self._blob = blob;
         self._length = Math.ceil(blob.size / self._partSize);
         self._part = 0;
-        self._md5 = new md5_1.Md5();
+        self._md5 = new Md5();
         self._processPart();
     };
     Md5FileHasher.prototype._fail = function () {

--- a/package.json
+++ b/package.json
@@ -40,5 +40,5 @@
     "test": "node node_modules/karma/bin/karma start karma.conf.js"
   },
   "types": "dist/md5.d.ts",
-  "version": "1.2.6"
+  "version": "1.2.7"
 }


### PR DESCRIPTION
Require was not removed after latest builds on the service worker. Since require is not available here and since the required class is in the same file, we can safely remove them.

closes: #21 

@stakach